### PR TITLE
Timeout and memory

### DIFF
--- a/serverless/functions.cjs
+++ b/serverless/functions.cjs
@@ -6,7 +6,8 @@ async function buildFunctions({ resolveVariable }) {
             const newFunction = {
                 [configItem.adapter]: {
                     "handler": `adapters/${configItem.adapter}.handler`,
-                    "timeout": 300
+                    "timeout": 600,
+                    "memorySize": 512
                 }
             }
             return { ...acc, ...newFunction }

--- a/serverless/functions.cjs
+++ b/serverless/functions.cjs
@@ -6,8 +6,8 @@ async function buildFunctions({ resolveVariable }) {
             const newFunction = {
                 [configItem.adapter]: {
                     "handler": `adapters/${configItem.adapter}.handler`,
-                    "timeout": 600,
-                    "memorySize": 512
+                    "timeout": 600, // in seconds
+                    "memorySize": 512 // in MB
                 }
             }
             return { ...acc, ...newFunction }

--- a/serverless/functions.cjs
+++ b/serverless/functions.cjs
@@ -6,6 +6,7 @@ async function buildFunctions({ resolveVariable }) {
             const newFunction = {
                 [configItem.adapter]: {
                     "handler": `adapters/${configItem.adapter}.handler`,
+                    "timeout": 300
                 }
             }
             return { ...acc, ...newFunction }

--- a/serverless/functions.cjs
+++ b/serverless/functions.cjs
@@ -6,7 +6,7 @@ async function buildFunctions({ resolveVariable }) {
             const newFunction = {
                 [configItem.adapter]: {
                     "handler": `adapters/${configItem.adapter}.handler`,
-                    "timeout": 600, // in seconds
+                    "timeout": 90, // in seconds
                     "memorySize": 512 // in MB
                 }
             }


### PR DESCRIPTION
Needed to raise the timeout for watsonville, not sure what a good timeout is. Maybe we can set the timeout very high and adjust the alarm to alert us incase it does go for a long time. Then we can adjust the alarm if it is normal, or fix the lambda if it's from errors.

Max memory Usage with an xlsx file of 2000 rows was ~ 150 MB, lowered default from 1 GB to 500 MB. Still a lot of headroom but should save on costs. If lambda calculates cost by what is used instead of what is allocated, then this is unnecessary.